### PR TITLE
Amended definition of commutative group

### DIFF
--- a/content/kapitel2.tex
+++ b/content/kapitel2.tex
@@ -202,7 +202,7 @@ Wenn die Gruppe kommutativ ist, dann wird die Gruppenoperation auch oft durch $ 
 	\item $ na := \underbrace{a+ \ldots + a}_{n-mal} $ für alle $ n \in \N $ und $ a \in G $
 	\item Das neutrale Element wird durch $ 0 $ bezeichnet.
 \end{itemize}
-In einer kommutativen Gruppe $ (G, \cdot) $ gilt:
+In einer kommutativen Gruppe $ (G, +) $ gilt:
 \begin{itemize}
 	\item
 		$ (a+b)+c = a+(b+c) \quad \forall a,b,c \in G $


### PR DESCRIPTION
The commutative group was defined with the operation \cdot, but in the following axioms, + was used.