### PR TITLE
Amended definition of subvector space

### DIFF
--- a/content/kapitel3.tex
+++ b/content/kapitel3.tex
@@ -116,7 +116,7 @@ Sei $ V $ Vektorraum über $ \K $ und sei $ W \subseteq V $. Dann heißt $ W $ U
 
 \begin{itemize}[leftmargin=\myindent]
 	\item[(UV1)]
-		$ W \neq 0 $
+		$ W \neq \emptyset $
 	\item[(UV2)]
 		$ v,w \in W \Rightarrow v+w \in W $
 	\item[(UV3)]


### PR DESCRIPTION
The subvector space W was defined with W \neq 0, but W \neq \emptyset was intended.